### PR TITLE
Flexibility for the user remove/include meta info

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,12 +43,16 @@ function getCode(body) {
 
 module.exports = {
   'application/vnd.api+json': function jsonapiFormatter(req, res, body) {
-    const response = {
-      meta: {
-        id: req.id(),
-        ...res.meta || {},
-      },
-    };
+    const response = {}
+    if (res.meta !== undefined) {
+      response.meta = res.meta
+    } else {
+      response.meta = { id: req.id() }
+      if (!isProd) {
+        response.meta.timers = req.timers;
+        response.meta.path = req.path();
+      }
+    }
 
     if (res.links !== undefined) {
       response.links = { ...res.links };
@@ -56,11 +60,6 @@ module.exports = {
 
     if (res.included !== undefined) {
       response.included = [...res.included];
-    }
-
-    if (!isProd) {
-      response.meta.timers = req.timers;
-      response.meta.path = req.path();
     }
 
     if (body instanceof Error) {


### PR DESCRIPTION
When user informs his meta object we don't include additional information on it.
If meta isn't informed, we include requestID 
In case it isn't production env, timer and path are included